### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Used for 'configurationFile' in `.github/workflows/renovate.yml`",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "platform": "github",
+  "platformCommit": "enabled",
   "repositories": [
     "matijs/renovate-config",
     "matijs/til",


### PR DESCRIPTION
The logs were showing that the config needed migrating. The original config contained `config:base`. In the migrated config, this was migrated to `config:recommended` so let's use this.

Also use GitHub's API to do commits so that they are signed.